### PR TITLE
feat: DBからタイルデータを落とす機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,39 +15,64 @@ Usage: main [OPTIONS]
   https://github.com/jaoafa/DynmapProcessor#readme
 
 Options:
-  -i, --input PATH    The directory of tile images.
-  -o, --output PATH   The directory to output generated images and metadata.
-  -c, --cache         Whether to allow the use of cached basemap. (Skip
-                      basemap generation from scratch)
-  -z, --zoom INT      Specify the zoom level from 0 to 4 (4 by default)
-  -g, --grid          Whether to enable chunk grid.
-  -e, --edit          Whether to enable image editing.
-  -m, --markers PATH  The file path to the JSON file that configures markers.
-  -t, --trim TEXT     Trim to the specified area. Format: x1,y1,x2,y2
-  -h, --height INT    Height of the map image. Using this with the width
-                      option might cause distortion.
-  -w, --width INT     Width of the map image. Using this with the height
-                      option might cause distortion.
-  -r, --resize FLOAT  Scale up (or down) the output image to the specified
-                      scale rate. (0<x<1 to scale down, 1<x to scale up)
-  --help              Show this message and exit
+  -t, --type [FILE|DATABASE]  Input type
+  -i, --input PATH            The directory of tile images.
+  -j, --jdbc-url TEXT         JDBC URL to connect to the dynmap database.
+  -u, --db-user TEXT          Database user name.
+  -p, --db-password TEXT      Database user password.
+  --db-table-prefix TEXT      Database table name.
+  --db-map-id INT             Map ID.
+  -o, --output PATH           The directory to output generated images and
+                              metadata.
+  --cache                     Whether to allow the use of cached basemap.
+                              (Skip basemap generation from scratch)
+  -z, --zoom INT              Specify the zoom level from 0 to 4 (4 by
+                              default)
+  -g, --grid                  Whether to enable chunk grid.
+  -e, --edit                  Whether to enable image editing.
+  -m, --markers PATH          The file path to the JSON file that configures
+                              markers.
+  -c, --clip TEXT             Clip the specified area from the map image.
+                              Format: x1,y1,x2,y2
+  -h, --height INT            Height of the map image. Using this with the
+                              width option might cause distortion.
+  -w, --width INT             Width of the map image. Using this with the
+                              height option might cause distortion.
+  -r, --resize FLOAT          Scale up (or down) the output image to the
+                              specified scale rate. (0<x<1 to scale down, 1<x
+                              to scale up)
+  --help                      Show this message and exit
 ```
 </details>
 
 ## Options
-| Type    | Name                                                | Flags            |  
-|---------|-----------------------------------------------------|------------------|  
-| `PATH`  | [Input](#input--i-or---input)                       | `-i` `--input`   |  
-| `PATH`  | [Output](#output--o-or---output)                    | `-o` `--output`  |  
-| `BOOL`  | [Cache](#cache--c-or---cache)                       | `-c` `--cache`   |  
-| `INT`   | [Zoom level](#zoom-level--z-or---zoom-4-by-default) | `-z` `--zoom`    |  
-| `BOOL`  | [Grid](#grid--g-or---grid-false-by-default)         | `-g` `--grid`    |  
-| `BOOL`  | [Edit](#edit--e-or---edit-false-by-default)         | `-e` `--edit`    |
-| `PATH`  | [Markers](#markers--m-or---markers)                 | `-m` `--markers` |
-| `TEXT`  | [Trim](#trim--t-or---trim)                          | `-t` `--trim`    |
-| `INT`   | [Height](#height-and-width--h-w-or---height--width) | `-h` `--height`  |
-| `INT`   | [Width](#height-and-width--h-w-or---height--width)  | `-w` `--width`   |
-| `FLOAT` | [Resize](#resize--r-or---resize-1-by-default)       | `-r` `--resize`  |
+| Type    | Name                                                  | Flags                |  
+|---------|-------------------------------------------------------|----------------------|
+| `ENUM`  | [Input type](#input-type--t-or---type)                | `-t` `--type`        |
+| `PATH`  | [Input](#input--i-or---input)                         | `-i` `--input`       |
+| `TEXT`  | [JDBC URL](#database-)                                | `-j` `--jbdc-url`    |
+| `TEXT`  | [Database User](#database-)                           | `-u` `--db-user`     |
+| `TEXT`  | [Database Password](#database-)                       | `-p` `--db-password` |
+| `TEXT`  | [Database Table Prefix](#database-)                   | `--db-table-prefix`  |
+| `INT`   | [Database Map ID](#database-)                         | `--db-map-id`        |
+| `PATH`  | [Output](#output--o-or---output)                      | `-o` `--output`      |  
+| `BOOL`  | [Cache](#cache--c-or---cache)                         | `--cache`            |  
+| `INT`   | [Zoom level](#zoom-level--z-or---zoom-4-by-default)   | `-z` `--zoom`        |  
+| `BOOL`  | [Grid](#grid--g-or---grid-false-by-default)           | `-g` `--grid`        |  
+| `BOOL`  | [Edit](#edit--e-or---edit-false-by-default)           | `-e` `--edit`        |
+| `PATH`  | [Markers](#markers--m-or---markers)                   | `-m` `--markers`     |
+| `TEXT`  | [Clip](#clip--c-or---clip)                            | `-c` `--clip`        |
+| `INT`   | [Height](#height-and-width--h--w-or---height---width) | `-h` `--height`      |
+| `INT`   | [Width](#height-and-width--h--w-or---height---width)  | `-w` `--width`       |
+| `FLOAT` | [Resize](#resize--r-or---resize-1-by-default)         | `-r` `--resize`      |
+
+### Input type: `-t` or `--type`
+> Example: `-t DATABASE`
+
+Where to get tile images.  
+`FILE` or `DATABASE`.
+
+---
 
 ### Input: `-i` or `--input`
 > Example: `-i ./input_images`  
@@ -68,6 +93,15 @@ input_images
     zoom-4
         ...
 ```
+
+---
+
+### Database: 
+`-j`, `-u`, `-p` or `--jdbc-url`, `--db-user`, `--db-password`, `--db-table-prefix`, `--db-map-id`
+> Example: `-j jdbc:mysql://localhost:1234 -u someone -p password --db-table-prefix dynmap --db-map-id 1234`
+
+Define the database information to download images from.  
+`--db-table-prefix` is `dmap` by default.
 
 ---
 
@@ -135,15 +169,15 @@ See [Marker file](#marker-file)
 
 ---
 
-### Trim: `-t` or `--trim`
-> Example: `-t 1000,1000,-1000,-1000`
+### Clip: `-c` or `--clip`
+> Example: `-c 1000,1000,-1000,-1000`
 
-Trim to the specified area.  
+Clip the specified area from the map image.  
 Format: `x1,y1,x2,y2`
 
 ---
 
-### Height and width: `-h`,`-w` or `--height`,`--width`
+### Height and width: `-h`, `-w` or `--height`, `--width`
 > Example: `-w 1000` / `-h 500`
 
 Height or width of the map image.  

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
     implementation("com.github.ajalt.clikt:clikt:3.5.1")
+    implementation("com.mysql:mysql-connector-j:8.0.32")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,12 +1,15 @@
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.double
+import com.github.ajalt.clikt.parameters.types.enum
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.path
 import com.sksamuel.scrimage.nio.PngWriter
 import kotlinx.serialization.json.Json
 import markers.Markers
 import java.io.File
+import java.nio.file.Files.createTempDirectory
 import java.nio.file.Path
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -15,6 +18,11 @@ import java.time.format.DateTimeFormatter
 // 128 * 128
 // 0-0.png -> 0,-64
 
+enum class InputType {
+    FILE,
+    DATABASE
+}
+
 class Main : CliktCommand(
     help = """
         Welcome to Dynmap Processor.  
@@ -22,10 +30,41 @@ class Main : CliktCommand(
         For more detailed information, please refer to https://github.com/jaoafa/DynmapProcessor#readme
 """.trimIndent()
 ) {
+    val inputType by option(
+        "-t",
+        "--type",
+        help = "Input type"
+    ).enum<InputType>().default(InputType.FILE)
+
     val images by option(
         "-i", "--input",
         help = "The directory of tile images."
-    ).path(mustExist = true, canBeFile = false).required()
+    ).path(mustExist = true, canBeFile = false)
+
+    val jdbcUrl by option(
+        "-j", "--jdbc-url",
+        help = "JDBC URL to connect to the dynmap database."
+    ).check { it.startsWith("jdbc:mysql://") }
+
+    val dbUser by option(
+        "-u", "--db-user",
+        help = "Database user name."
+    )
+
+    val dbPassword by option(
+        "-p", "--db-password",
+        help = "Database user password."
+    )
+
+    val dbTablePrefix by option(
+        "--db-table-prefix",
+        help = "Database table name."
+    ).default("dmap")
+
+    val dbMapId by option(
+        "--db-map-id",
+        help = "Map ID."
+    ).int().default(1)
 
     val output by option(
         "-o", "--output",
@@ -59,9 +98,9 @@ class Main : CliktCommand(
         help = "The file path to the JSON file that configures markers."
     ).path(mustExist = true, canBeDir = false)
 
-    val trim by option(
-        "-t", "--trim",
-        help = "Trim to the specified area. Format: x1,y1,x2,y2"
+    val clip by option(
+        "--clip",
+        help = "Clipping to the specified area. Format: x1,y1,x2,y2"
     ).split(",").check("Length of the list must be 4. For example: 120,150,-10,10") { it.size == 4 }
 
     val height by option(
@@ -82,15 +121,31 @@ class Main : CliktCommand(
     override fun run() {
         val chunkImageResolution = 128
 
+        checkArguments()
+
         val outputString = output.toString()
 
         val basemapExists = MapImage.basemapFile(outputString).exists()
         val metadataExists = MapImage.metadataFile(outputString).exists()
 
+        val inputDirectory = getInputDirectory()
+
+        if(jdbcUrl != null && dbUser != null && dbPassword != null) {
+            println("Downloading tiles from database...")
+            val db = TileDatabase(
+                jdbcUrl!!,
+                dbUser!!,
+                dbPassword!!,
+                dbTablePrefix
+            )
+            db.downloadAll(dbMapId, inputDirectory)
+            println("Download complete.")
+        }
+
         val mapImage =
             if (basemapExists && metadataExists && cache)
-                MapImage.load(outputString, images.toString())
-            else MapImage.create(outputString, images.toString(), zoom, chunkImageResolution, grid)
+                MapImage.load(outputString, inputDirectory)
+            else MapImage.create(outputString, inputDirectory, zoom, chunkImageResolution, grid)
 
         if (edit) {
             val markerFile = File(this.markers.toString())
@@ -102,7 +157,7 @@ class Main : CliktCommand(
                 ) else Markers(emptyList()),
                 height,
                 width,
-                trim?.map { it.toInt() },
+                clip?.map { it.toInt() },
                 resize
             )
 
@@ -112,6 +167,29 @@ class Main : CliktCommand(
             editedMapImage.output(PngWriter.NoCompression, Path.of(outputString, filename))
             println("Image edit complete.")
         }
+    }
+
+    private fun checkArguments() {
+        if (inputType == InputType.FILE) {
+            if (images == null) {
+                throw UsageError("Please specify the input directory.")
+            }
+        } else if (inputType == InputType.DATABASE) {
+            if (jdbcUrl == null || dbUser == null || dbPassword == null) {
+                throw UsageError("Please specify the database connection information.")
+            }
+        }
+    }
+
+    private fun getInputDirectory(): String {
+        if (inputType == InputType.FILE) {
+            return images.toString()
+        } else if (inputType == InputType.DATABASE) {
+            val tempDir = createTempDirectory("dynmap-processor").toFile()
+            tempDir.deleteOnExit()
+            return tempDir.absolutePath
+        }
+        throw IllegalStateException("Unknown input type: $inputType")
     }
 }
 

--- a/src/main/kotlin/TileDatabase.kt
+++ b/src/main/kotlin/TileDatabase.kt
@@ -1,0 +1,45 @@
+import java.io.File
+import java.sql.Connection
+import java.sql.DriverManager
+
+class TileDatabase(
+    private val jdbcUrl: String,
+    private val username: String,
+    private val password: String,
+    private val tablePrefix: String
+) {
+    fun downloadAll(mapId: Int, output: String) {
+        val connection: Connection = DriverManager.getConnection(
+            jdbcUrl,
+            username,
+            password
+        )
+
+        val tableName = "${tablePrefix}_Tiles"
+        val statement = connection.prepareStatement(
+            "SELECT * FROM $tableName WHERE MapID = ?"
+        )
+        statement.setInt(1, mapId)
+        val resultSet = statement.executeQuery()
+
+        while (resultSet.next()) {
+            val x = resultSet.getInt("x")
+            val y = resultSet.getInt("y")
+            val zoom = resultSet.getInt("zoom")
+            val data = resultSet.getBytes("NewImage")
+
+            println("Downloading: zoom=$zoom, x=$x, y=$y")
+
+            val file = File(getFilePath(output, x, y, zoom))
+            if(!file.parentFile.exists()){
+                file.parentFile.mkdirs()
+            }
+            file.writeBytes(data)
+        }
+
+        resultSet.close()
+        connection.close()
+    }
+
+    private fun getFilePath(parent: String, x: Int, y: Int, zoom: Int) = "$parent/zoom-${zoom}/${x}_${y}.png"
+}


### PR DESCRIPTION
- close #7 

DynmapのタイルデータをMySQLなどデータベースで管理している場合のために(そう、うちのこと)、DBからタイルデータを落として生成する機能を追加しました。
`java -jar .\build\libs\DynmapProcessor-1.0.0.jar -t database -j jdbc:mysql://localhost:3306/dynmap -u dynmap -p password -o data/output -e` のように指定することで利用できます。
データベースから落とした画像データはテンポラリディレクトリに保存され、アプリケーションの終了時に自動削除されます。

また、短引数の関係もあって `trim` を `clip` に変更しました。
（`trim` って誰においても削って構わない部分 = 例えば空白とかを削る意味合いの方が強いと思っていて、この機能はユーザーが切り出してほしい部分なので、若干意味合いがズレるかなあと。）

引数の差分は以下の通り:

```diff
--- a.txt
+++ b.txt
@@ -6,14 +6,20 @@
  https://github.com/jaoafa/DynmapProcessor#readme

 Options:
+ -t, --type [FILE|DATABASE] Input type
  -i, --input PATH The directory of tile images.
+ -j, --jdbc-url TEXT JDBC URL to connect to the dynmap database.
+ -u, --db-user TEXT Database user name.
+ -p, --db-password TEXT Database user password.
+ --db-table-prefix TEXT Database table name.
+ --db-map-id INT Map ID.
  -o, --output PATH The directory to output generated images and metadata.
  -c, --cache Whether to allow the use of cached basemap. (Skip basemap generation from scratch)
  -z, --zoom INT Specify the zoom level from 0 to 4 (4 by default)
  -g, --grid Whether to enable chunk grid.
  -e, --edit Whether to enable image editing.
  -m, --markers PATH The file path to the JSON file that configures markers.
- -t, --trim TEXT Trim to the specified area. Format: x1,y1,x2,y2
+ --clip TEXT Clipping to the specified area. Format: x1,y1,x2,y2
  -h, --height INT Height of the map image. Using this with the width option might cause distortion.
  -w, --width INT Width of the map image. Using this with the height option might cause distortion.
  -r, --resize FLOAT Scale up (or down) the output image to the specified scale rate. (0<x<1 to scale down, 1<x to scale up)
```